### PR TITLE
fixed width grid margin/width

### DIFF
--- a/src/shared.css
+++ b/src/shared.css
@@ -36,15 +36,20 @@
 	.grid-fixed-center {
 		margin-left: auto;
 		margin-right: auto;
-		width: calc(var(--fixed-width-cutoff) - var(--gutter-small));
+		width: auto;
+		max-width: calc(var(--fixed-width-cutoff) - var(--gutter-small));
 
 		@media (--fixed-grid-applies-large-gutter) {
-			width: calc(var(--fixed-width-cutoff) - var(--gutter-large));
+			max-width: calc(var(--fixed-width-cutoff) - var(--gutter-large));
 		}
 	}
 
 	.grid-fixed-left {
-		margin-left: 0;
+		margin-left: var(--half-gutter-small);
+
+		@media (--use-large-gutter) {
+			margin-left: var(--half-gutter-large);
+		}
 	}
 }
 


### PR DESCRIPTION
- Preserve margin for fixed width, left aligned grids.  it was being set to 0, which pulled content to the left
- Set width auto and specify a max width instead.  At widths close to the cutoff, the grid may overflow its container if we explicitly set width.